### PR TITLE
Make crc work for aiooss2

### DIFF
--- a/aiooss2/api.py
+++ b/aiooss2/api.py
@@ -38,8 +38,6 @@ from oss2.utils import (
     content_md5,
     is_valid_bucket_name,
     is_valid_endpoint,
-    make_crc_adapter,
-    make_progress_adapter,
     set_content_type,
 )
 from oss2.xml_utils import (
@@ -53,7 +51,7 @@ from oss2.xml_utils import (
 from .exceptions import make_exception
 from .http import AioSession, Request
 from .models import AioGetObjectResult
-from .utils import copyfileobj_and_verify
+from .utils import copyfileobj_and_verify, make_adapter
 
 if TYPE_CHECKING:
     from oss2 import AnonymousAuth, Auth, StsAuth
@@ -276,11 +274,11 @@ class AioBucket(_AioBase):
         """
         headers = set_content_type(CaseInsensitiveDict(headers), key)
 
-        if progress_callback:
-            data = make_progress_adapter(data, progress_callback)
-
-        if self.enable_crc:
-            data = make_crc_adapter(data)
+        data = make_adapter(
+            data,
+            progress_callback=progress_callback,
+            enable_crc=self.enable_crc,
+        )
 
         resp: "AioResponse" = await self.__do_object(
             "PUT", key, data=data, headers=headers
@@ -492,11 +490,11 @@ class AioBucket(_AioBase):
         """
         headers = set_content_type(CaseInsensitiveDict(headers), key)
 
-        if progress_callback:
-            data = make_progress_adapter(data, progress_callback)
-
-        if self.enable_crc and init_crc is not None:
-            data = make_crc_adapter(data, init_crc)
+        data = make_adapter(
+            data,
+            progress_callback=progress_callback,
+            enable_crc=self.enable_crc,
+        )
 
         resp = await self.__do_object(
             "POST",

--- a/aiooss2/api.py
+++ b/aiooss2/api.py
@@ -98,7 +98,7 @@ class _AioBase:  # pylint: disable=too-few-public-methods
         self.session = session
         self.timeout = connect_timeout or defaults.connect_timeout
         self.app_name = app_name
-        self.enable_crc = False
+        self.enable_crc = enable_crc
         self.proxies = proxies
 
         self._make_url = _UrlMaker(self.endpoint, is_cname)
@@ -578,27 +578,27 @@ class AioBucket(_AioBase):
             if result.content_length is None:
                 shutil.copyfileobj(result, f_w)
             else:
-                copyfileobj_and_verify(
+                await copyfileobj_and_verify(
                     result,
                     f_w,
                     result.content_length,
                     request_id=result.request_id,
                 )
 
-            if self.enable_crc and byte_range is None:
-                if (
-                    (headers is None)
-                    or ("Accept-Encoding" not in headers)
-                    or (headers["Accept-Encoding"] != "gzip")
-                ):
-                    check_crc(
-                        "get",
-                        result.client_crc,
-                        result.server_crc,
-                        result.request_id,
-                    )
+        if self.enable_crc and byte_range is None:
+            if (
+                (headers is None)
+                or ("Accept-Encoding" not in headers)
+                or (headers["Accept-Encoding"] != "gzip")
+            ):
+                check_crc(
+                    "get",
+                    result.client_crc,
+                    result.server_crc,
+                    result.request_id,
+                )
 
-            return result
+        return result
 
     async def batch_delete_objects(
         self, key_list: List[str], headers: Optional[Dict] = None

--- a/aiooss2/http.py
+++ b/aiooss2/http.py
@@ -70,7 +70,7 @@ class AioResponse(Response):
         super().__init__(response)
         self.__all_read = False
 
-    async def read(self, amt=None) -> bytes:
+    async def aread(self, amt=None) -> bytes:
         """read the contents from the response"""
         if self.__all_read:
             return b""
@@ -88,6 +88,9 @@ class AioResponse(Response):
 
         self.__all_read = True
         return content
+
+    async def read(self, amt=None) -> bytes:
+        return await self.aread(amt)
 
     async def __iter__(self):
         """content iterator"""

--- a/aiooss2/models.py
+++ b/aiooss2/models.py
@@ -1,18 +1,141 @@
 """
 Module for all input and output classes for the Python SDK API
 """
+import copy
+import logging
 from typing import TYPE_CHECKING
 
-from oss2.models import GetObjectResult
+from oss2.exceptions import ClientError
+from oss2.headers import (
+    DEPRECATED_CLIENT_SIDE_ENCRYPTION_KEY,
+    KMS_ALI_WRAP_ALGORITHM,
+    OSS_CLIENT_SIDE_ENCRYPTION_KEY,
+)
+from oss2.models import ContentCryptoMaterial, GetObjectResult, _hget
+
+from aiooss2.utils import make_adapter
 
 if TYPE_CHECKING:
     from .http import AioResponse
+
+
+logger = logging.getLogger(__name__)
 
 
 class AioGetObjectResult(GetObjectResult):
     """class for the result of api get_object"""
 
     resp: "AioResponse"
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        resp: "AioResponse",
+        progress_callback=None,
+        crc_enabled=False,
+        crypto_provider=None,
+        discard=0,
+    ):
+        super(GetObjectResult, self).__init__(resp)
+        self.__crypto_provider = crypto_provider
+
+        self.content_range = _hget(resp.headers, "Content-Range")
+        if self.content_range:
+            byte_range = self._parse_range_str(self.content_range)
+
+        self.stream = make_adapter(
+            self.resp,
+            progress_callback=progress_callback,
+            size=self.content_length,
+            enable_crc=crc_enabled,
+            discard=discard,
+        )
+
+        if self.__crypto_provider:
+            self._make_crypto(byte_range, discard)
+        else:
+            if (
+                OSS_CLIENT_SIDE_ENCRYPTION_KEY in resp.headers
+                or DEPRECATED_CLIENT_SIDE_ENCRYPTION_KEY in resp.headers
+            ):
+                logger.warning(
+                    "Using Bucket to get an encrypted object will return "
+                    "raw data, please confirm if you really want to do this"
+                )
+
+    def _make_crypto(self, byte_range, discard):
+        content_crypto_material = ContentCryptoMaterial(
+            self.__crypto_provider.cipher, self.__crypto_provider.wrap_alg
+        )
+        content_crypto_material.from_object_meta(self.resp.headers)
+
+        if content_crypto_material.is_unencrypted():
+            logger.info(
+                "The object is not encrypted, "
+                "use crypto provider is not recommended"
+            )
+        else:
+            crypto_provider = self.__crypto_provider
+            if (
+                content_crypto_material.mat_desc
+                != self.__crypto_provider.mat_desc
+            ):
+                logger.warning(
+                    "The material description of the object "
+                    "and the provider is inconsistent"
+                )
+                encryption_materials = (
+                    self.__crypto_provider.get_encryption_materials(
+                        content_crypto_material.mat_desc
+                    )
+                )
+                if encryption_materials:
+                    crypto_provider = (
+                        self.__crypto_provider.reset_encryption_materials(
+                            encryption_materials
+                        )
+                    )
+                else:
+                    raise ClientError(
+                        "There is no encryption materials "
+                        "match the material description of the object"
+                    )
+
+            plain_key = crypto_provider.decrypt_encrypted_key(
+                content_crypto_material.encrypted_key
+            )
+            if content_crypto_material.deprecated:
+                if content_crypto_material.wrap_alg == KMS_ALI_WRAP_ALGORITHM:
+                    plain_counter = int(
+                        crypto_provider.decrypt_encrypted_iv(
+                            content_crypto_material.encrypted_iv, True
+                        )
+                    )
+                else:
+                    plain_counter = int(
+                        crypto_provider.decrypt_encrypted_iv(
+                            content_crypto_material.encrypted_iv
+                        )
+                    )
+            else:
+                plain_iv = crypto_provider.decrypt_encrypted_iv(
+                    content_crypto_material.encrypted_iv
+                )
+
+            offset = 0
+            if self.content_range:
+                start, _ = crypto_provider.adjust_range(
+                    byte_range[0], byte_range[1]
+                )
+                offset = content_crypto_material.cipher.calc_offset(start)
+
+            cipher = copy.copy(content_crypto_material.cipher)
+            if content_crypto_material.deprecated:
+                cipher.initial_by_counter(plain_key, plain_counter + offset)
+            else:
+                cipher.initialize(plain_key, plain_iv, offset)
+            self.stream = crypto_provider.make_decrypt_adapter(
+                self.stream, cipher, discard
+            )
 
     async def __aenter__(self):
         return self

--- a/aiooss2/models.py
+++ b/aiooss2/models.py
@@ -37,6 +37,7 @@ class AioGetObjectResult(GetObjectResult):
     ):
         super(GetObjectResult, self).__init__(resp)
         self.__crypto_provider = crypto_provider
+        self.__crc_enabled = crc_enabled
 
         self.content_range = _hget(resp.headers, "Content-Range")
         if self.content_range:
@@ -142,3 +143,14 @@ class AioGetObjectResult(GetObjectResult):
 
     async def __aexit__(self, *args):
         self.resp.release()
+
+    @property
+    def client_crc(self):
+        if self.__crc_enabled:
+            return self.stream.crc
+        return None
+
+    async def read(
+        self, amt=None
+    ):  # pylint: disable=invalid-overridden-method
+        return await self.stream.aread(amt)


### PR DESCRIPTION
fix: #37

1. Add a new make adapter method merge the old progress callback and crc one.
2. replace the make adapter function with only one function.
3. Add a new Payload for  `_BytesAndFileAdapter`
4. Register Payload to `PAYLOAD_REGISTRY`
5. Modify AioGetObjectResult's `__init__` to replace the old adapters with new ones.
6. Modify AioResponse to implement `amt` argument.
7. Open enable_crc arg for aiooss2.
8. Make adapters async to make enable_crc work.
9. Add pytest parameters to test both value of enable_crc.