### PR TITLE
Add size option to FilelikeObjectAdapter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
           - flake8-comprehensions
           - flake8-debugger
           - flake8-string-format
-    repo: https://gitlab.com/pycqa/flake8
+    repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
   - repo: local
     hooks:

--- a/aiooss2/models.py
+++ b/aiooss2/models.py
@@ -3,7 +3,7 @@ Module for all input and output classes for the Python SDK API
 """
 import copy
 import logging
-from typing import TYPE_CHECKING, Awaitable, Optional
+from typing import TYPE_CHECKING, Awaitable
 
 from oss2.exceptions import ClientError
 from oss2.headers import (
@@ -166,11 +166,11 @@ class AioGetObjectResult(HeadObjectResult):
             return self.stream.crc
         return None
 
-    async def read(self, amt: Optional[int] = None) -> Awaitable[bytes]:
+    async def read(self, amt: int = -1) -> Awaitable[bytes]:
         """async read data from stream
 
         Args:
-            amt (int, optional): batch size of the data to read
+            amt int: batch size of the data to read
 
         Returns:
         Awaitable[bytes]:

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -21,6 +21,7 @@ from aiooss2.utils import make_adapter
 
 if TYPE_CHECKING:
     from oss2 import Bucket
+    from py.path import local
 
     from aiooss2.api import AioBucket
 
@@ -140,3 +141,17 @@ def test_make_adapter_error():
         assert make_adapter(
             ["data1", "data2", "data3"], discard=1, enable_crc=True
         )
+
+
+def test_adapter_read(
+    tmpdir: "local",
+):
+    data = b"123456789"
+    file = tmpdir / "file"
+    file.write(data)
+
+    with open(str(file), "rb") as f_r:
+        f_r.seek(3, os.SEEK_SET)
+        adaptor = FilelikeObjectAdapter(f_r, size=5)
+        result = asyncio.run(adaptor.read())
+        assert result == b"45678"


### PR DESCRIPTION
fix: #59

Because in resumable uploading we need to upload chunks of the file stream. size option is need for FilelikeObjectAdapter

1. Add `size` option for FilelikeObjectAdapter
2. Add a unit test for FilelikeObjectAdapter's reading.