### PR TITLE
Add new api `resumable_upload`

### DIFF
--- a/aiooss2/exceptions.py
+++ b/aiooss2/exceptions.py
@@ -2,11 +2,26 @@
 Module for exceptions classes used in aiooss2
 """
 
+from oss2.exceptions import _OSS_ERROR_TO_EXCEPTION
 from oss2.exceptions import (
-    _OSS_ERROR_TO_EXCEPTION,
-    ServerError,
-    _parse_error_body,
+    InvalidEncryptionRequest as _InvalidEncryptionRequest,
 )
+from oss2.exceptions import ServerError, _parse_error_body
+
+
+class InvalidEncryptionRequest(_InvalidEncryptionRequest):
+    """Invalid encryption request error class."""
+
+    def __init__(self, message, details):
+        super().__init__(
+            self.status,
+            {},
+            f"InconsistentError: {message}",
+            {"details": details},
+        )
+
+    def __str__(self):
+        return self._str_with_body()
 
 
 async def make_exception(resp):

--- a/aiooss2/multipart.py
+++ b/aiooss2/multipart.py
@@ -1,0 +1,355 @@
+"""
+Module for multipart operations
+"""
+# pylint: disable=protected-access
+# pylint: disable=too-many-arguments
+
+import logging
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Union,
+)
+
+from oss2.api import _make_range_string
+from oss2.headers import OSS_COPY_OBJECT_SOURCE_RANGE
+from oss2.http import CaseInsensitiveDict
+from oss2.models import (
+    InitMultipartUploadResult,
+    ListMultipartUploadsResult,
+    ListPartsResult,
+    PutObjectResult,
+    RequestResult,
+)
+from oss2.utils import calc_obj_crc_from_parts, check_crc, set_content_type
+from oss2.xml_utils import (
+    parse_init_multipart_upload,
+    parse_list_multipart_uploads,
+    parse_list_parts,
+    to_complete_upload_request,
+)
+
+from .utils import make_adapter
+
+if TYPE_CHECKING:
+    from oss2.models import PartInfo
+
+    from aiooss2.api import AioBucket
+
+
+logger = logging.getLogger(__name__)
+
+
+async def init_multipart_upload(
+    self: "AioBucket",
+    key: str,
+    headers: Optional[Union[Dict, CaseInsensitiveDict]] = None,
+    params: Optional[Dict] = None,
+) -> InitMultipartUploadResult:
+    """initialize multipart uploading
+    The returning upload id, bucket name and object name together
+    defines this uploading event.
+
+    Args:
+        key (str): key value of the object
+        headers (Optional[Union[Dict, CaseInsensitiveDict]], optional):
+            HTTP headers to specify.
+        params (Optional[Dict], optional):
+
+    Returns:
+        InitMultipartUploadResult:
+    """
+    headers = set_content_type(CaseInsensitiveDict(headers), key)
+
+    if params is None:
+        tmp_params = {}
+    else:
+        tmp_params = params.copy()
+
+    tmp_params["uploads"] = ""
+    logger.debug("Start to init multipart upload")
+    resp = await self._do_object(
+        "POST", key, params=tmp_params, headers=headers
+    )
+    logger.debug("Init multipart upload done")
+    return await self._parse_result(
+        resp, parse_init_multipart_upload, InitMultipartUploadResult
+    )
+
+
+async def upload_part(
+    self: "AioBucket",
+    key: str,
+    upload_id: str,
+    part_number: int,
+    data: Any,
+    progress_callback: Optional[Callable] = None,
+    headers: Optional[Union[Dict, CaseInsensitiveDict]] = None,
+) -> PutObjectResult:
+    """upload one part
+
+    Args:
+        key (str): key value of the object
+        upload_id (str): the upload event id
+        part_number (int): the part number of this upload
+        data (Any): contents to upload
+        headers (Optional[Union[Dict, CaseInsensitiveDict]], optional):
+            HTTP headers to specify.
+        progress_callback (Optional[Callable], optional): callback function
+            for progress bar.
+
+    Returns:
+        PutObjectResult: PutObjectResult
+    """
+
+    headers = CaseInsensitiveDict(headers)
+
+    data = make_adapter(
+        data,
+        progress_callback=progress_callback,
+        enable_crc=self.enable_crc,
+    )
+
+    logger.debug("Start to upload multipart")
+
+    resp = await self._do_object(
+        "PUT",
+        key,
+        params={"uploadId": upload_id, "partNumber": str(part_number)},
+        headers=headers,
+        data=data,
+    )
+    logger.debug("Upload multipart done")
+    result = PutObjectResult(resp)
+
+    if self.enable_crc and result.crc is not None:
+        check_crc("upload part", data.crc, result.crc, result.request_id)
+
+    return result
+
+
+async def complete_multipart_upload(
+    self: "AioBucket",
+    key: str,
+    upload_id: str,
+    parts: List["PartInfo"],
+    headers: Optional[Union[Dict, CaseInsensitiveDict]] = None,
+) -> PutObjectResult:
+    """Complete multipart uploading process create a new file.
+
+    Args:
+        key (str): key value of the object
+        upload_id (str): the upload event id
+        parts (List[PartInfo]): list of PathInfo
+        headers (Optional[Union[Dict, CaseInsensitiveDict]], optional):
+            HTTP headers to specify.
+
+    Returns:
+        PutObjectResult:
+    """
+
+    headers = CaseInsensitiveDict(headers)
+
+    if parts is not None:
+        parts = sorted(parts, key=lambda p: p.part_number)
+        data = to_complete_upload_request(parts)
+    else:
+        data = None
+
+    logger.debug("Start to complete multipart upload")
+
+    resp = await self._do_object(
+        "POST",
+        key,
+        params={"uploadId": upload_id},
+        data=data,
+        headers=headers,
+    )
+    logger.debug("Complete multipart upload %s done.", upload_id)
+
+    result = PutObjectResult(resp)
+
+    if self.enable_crc and parts is not None:
+        object_crc = calc_obj_crc_from_parts(parts)
+        check_crc(
+            "multipart upload", object_crc, result.crc, result.request_id
+        )
+
+    return result
+
+
+async def abort_multipart_upload(
+    self: "AioBucket",
+    key: str,
+    upload_id: str,
+    headers: Optional[Union[Dict, CaseInsensitiveDict]] = None,
+) -> RequestResult:
+    """abort multipart uploading process
+
+    Args:
+        key (str): key value of the object
+        upload_id (str): the upload event id
+        headers (Optional[Union[Dict, CaseInsensitiveDict]], optional):
+            HTTP headers to specify.
+
+    Returns:
+        RequestResult:
+    """
+
+    logger.debug("Start to abort multipart upload")
+
+    headers = CaseInsensitiveDict(headers)
+
+    resp = await self._do_object(
+        "DELETE", key, params={"uploadId": upload_id}, headers=headers
+    )
+    logger.debug("Abort multipart done")
+    return RequestResult(resp)
+
+
+async def list_multipart_uploads(
+    self: "AioBucket",
+    prefix: str = "",
+    delimiter: str = "",
+    key_marker: str = "",
+    upload_id_marker: str = "",
+    max_uploads: int = 1000,
+    headers: Optional[Union[Dict, CaseInsensitiveDict]] = None,
+) -> ListMultipartUploadsResult:
+    """List multipart uploading process
+
+    Args:
+        prefix (str, optional): Only list the parts with this prefix.
+        delimiter (str, optional): Directory delimiter.
+        key_marker (str, optional): Filename for paging. Do not required
+        in the first call of this function. Set to `next_key_marker`
+        from result in the following calls.
+        upload_id_marker (str, optional): paging seperator, Do not required
+        in the first call of this function. Set to `next_upload_id_marker`
+        from result in the following calls.
+        max_uploads (int, optional): max return numbers per page.
+        headers (Optional[Union[Dict, CaseInsensitiveDict]], optional):
+            HTTP headers to specify.
+
+    Returns:
+        ListMultipartUploadsResult:
+    """
+    logger.debug("Start to list multipart uploads")
+
+    headers = CaseInsensitiveDict(headers)
+
+    resp = await self._do_object(
+        "GET",
+        "",
+        params={
+            "uploads": "",
+            "prefix": prefix,
+            "delimiter": delimiter,
+            "key-marker": key_marker,
+            "upload-id-marker": upload_id_marker,
+            "max-uploads": str(max_uploads),
+            "encoding-type": "url",
+        },
+        headers=headers,
+    )
+    logger.debug("List multipart uploads done, req_id")
+    return await self._parse_result(
+        resp,
+        parse_list_multipart_uploads,
+        ListMultipartUploadsResult,
+    )
+
+
+async def upload_part_copy(
+    self: "AioBucket",
+    source_bucket_name: str,
+    source_key: str,
+    byte_range: Sequence[int],
+    target_key: str,
+    target_upload_id: str,
+    target_part_number: int,
+    headers: Optional[Union[Dict, CaseInsensitiveDict]] = None,
+    params: Optional[Dict] = None,
+) -> PutObjectResult:
+    """copy part or whole of a source file to a slice of a target file.
+
+    Args:
+        source_bucket_name (str): bucket name of the source file
+        source_key (str): key of the source file
+        byte_range (Sequence[int]): range of the source file to copy
+        target_key (str): key of the target file
+        target_upload_id (str): upload id of the target file
+        target_part_number (int): part number of the target file
+        headers (Optional[Union[Dict, CaseInsensitiveDict]], optional):
+            HTTP headers to specify.
+        params (Optional[Dict], optional):
+
+    Returns:
+        PutObjectResult:
+    """
+
+    headers = self._make_copy_source_headers(
+        source_bucket_name, source_key, headers, params
+    )
+
+    range_string = _make_range_string(byte_range)
+    if range_string:
+        headers[OSS_COPY_OBJECT_SOURCE_RANGE] = range_string
+
+    logger.debug("Start to upload part copy")
+
+    params = {} or params
+
+    params["uploadId"] = target_upload_id
+    params["partNumber"] = str(target_part_number)
+
+    resp = await self._do_object(
+        "PUT", target_key, params=params, headers=headers
+    )
+    logger.debug("Upload part copy done")
+
+    return PutObjectResult(resp)
+
+
+async def list_parts(
+    self: "AioBucket",
+    key: str,
+    upload_id: str,
+    marker: str = "",
+    max_parts: int = 1000,
+    headers: Optional[Union[Dict, CaseInsensitiveDict]] = None,
+) -> ListPartsResult:
+    """list uploaded parts in a part uploading progress.
+
+    Args:
+        key (str): key value of the object.
+        upload_id (str): the upload event id.
+        marker (str, optional): paging separator.
+        max_uploads (int, optional): max return numbers per page.
+        headers (Optional[Union[Dict, CaseInsensitiveDict]], optional):
+            HTTP headers to specify.
+
+    Returns:
+        ListPartsResult:
+    """
+    logger.debug("Start to list parts")
+
+    headers = CaseInsensitiveDict(headers)
+
+    resp = await self._do_object(
+        "GET",
+        key,
+        params={
+            "uploadId": upload_id,
+            "part-number-marker": marker,
+            "max-parts": str(max_parts),
+        },
+        headers=headers,
+    )
+    logger.debug("List parts done.")
+    return await self._parse_result(resp, parse_list_parts, ListPartsResult)

--- a/aiooss2/resumable.py
+++ b/aiooss2/resumable.py
@@ -1,0 +1,386 @@
+"""
+Module for resumable operations
+"""
+import asyncio
+import logging
+import os
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Collection,
+    Dict,
+    Mapping,
+    Optional,
+    Union,
+)
+
+from oss2 import Bucket, CryptoBucket
+from oss2.compat import to_string, to_unicode
+from oss2.defaults import multipart_num_threads as MULTIPART_NUM_THREADS
+from oss2.defaults import multipart_threshold as MULTIPART_THRESHOLD
+from oss2.defaults import part_size as PART_SIZE
+from oss2.exceptions import InconsistentError
+from oss2.headers import (
+    OSS_OBJECT_ACL,
+    OSS_REQUEST_PAYER,
+    OSS_SERVER_SIDE_DATA_ENCRYPTION,
+    OSS_SERVER_SIDE_ENCRYPTION,
+    OSS_TRAFFIC_LIMIT,
+)
+from oss2.models import ContentCryptoMaterial, MultipartUploadCryptoContext
+from oss2.resumable import (
+    PartInfo,
+    ResumableStore,
+    _filter_invalid_headers,
+    _PartToProcess,
+    _populate_valid_headers,
+    _populate_valid_params,
+    _ResumableUploader,
+    determine_part_size,
+)
+from oss2.utils import b64decode_from_string, b64encode_as_string
+
+from aiooss2.adapter import FilelikeObjectAdapter
+from aiooss2.exceptions import InvalidEncryptionRequest
+from aiooss2.iterators import AioPartIterator
+
+if TYPE_CHECKING:
+    from oss2.models import PutObjectResult
+
+    from aiooss2.api import AioBucket
+
+
+logger = logging.getLogger(__name__)
+
+
+async def resumable_upload(  # pylint: disable=too-many-arguments
+    bucket: Union["AioBucket", "CryptoBucket"],
+    key: Union[str, bytes],
+    filename: Union[str, bytes],
+    store: Optional["ResumableStore"] = None,
+    headers: Optional[Mapping] = None,
+    multipart_threshold: Optional[int] = None,
+    part_size: Optional[int] = None,
+    progress_callback: Optional[Callable] = None,
+    num_threads: Optional[int] = None,
+    params: Optional[Mapping] = None,
+) -> "PutObjectResult":
+    """Resumable upload local file , The implementation is spliting local
+    files to multipart, storing uploading information in local files. If the
+    uploading was interrupted by some reasons, only those remaied parts need
+    to be uploaded.
+
+    # Using `CryptoBucket` will make the upload fallback to the normal one.
+
+    Args:
+        bucket (Union[AioBucket, CryptoBucket]): bucket object to upload
+        key (Union[str, bytes]): object key to store the file
+        filename (Union[str, bytes]): filename to upload
+        store (Optional["ResumableStore"]): ResumableStore object to keep the
+            uploading info in the previous operation. Defaults to None.
+        headers (Optional[Mapping]): HTTP headers to send. Defaults to None.
+            # put_object or init_multipart_upload can make use of the whole
+                headers
+            # uplpad_part only accept OSS_REQUEST_PAYER, OSS_TRAFFIC_LIMIT
+            # complete_multipart_upload only accept OSS_REQUEST_PAYER,
+                OSS_OBJECT_ACL
+        multipart_threshold (Optional[int]): threshold to use multipart upload
+            instead of a normal one. Defaults to None.
+        part_size (Optional[int]): partion size of the multipart.
+            Defaults to None.
+        progress_callback (Optional[Callable]): callback function for
+            progress bar. Defaults to None.
+        num_threads (Optional[int]): concurrency number during the uploading
+            Defaults to None.
+        params (Optional[Mapping]): Defaults to None.
+
+    Returns:
+        PutObjectResult:
+    """
+    key_str = to_string(key)
+    filename_str = to_unicode(filename)
+    size = os.path.getsize(filename_str)
+
+    logger.debug(
+        "Start to resumable upload, bucket: %s, key: %s, filename: %s, "
+        "headers: %s, multipart_threshold: %s, part_size: %s, "
+        "num_threads: %s, size of file to upload is %s",
+        bucket.bucket_name,
+        key_str,
+        filename_str,
+        headers,
+        multipart_threshold,
+        part_size,
+        num_threads,
+        size,
+    )
+    multipart_threshold = multipart_threshold or MULTIPART_THRESHOLD
+    num_threads = num_threads or MULTIPART_NUM_THREADS
+    part_size = part_size or PART_SIZE
+
+    if size >= multipart_threshold and not isinstance(bucket, CryptoBucket):
+        store = store or ResumableStore()
+        uploader = ResumableUploader(
+            bucket,
+            key_str,
+            filename_str,
+            size,
+            store,
+            part_size=part_size,
+            headers=headers,
+            progress_callback=progress_callback,
+            num_threads=num_threads,
+            params=params,
+        )
+        result = await uploader.upload()
+    else:
+        result = await bucket.put_object_from_file(
+            key_str,
+            filename_str,
+            headers=headers,
+            progress_callback=progress_callback,
+        )
+
+    return result
+
+
+class ResumableUploader(_ResumableUploader):
+    """Resumable Uploader"""
+
+    bucket: "AioBucket"
+
+    async def upload(  # pylint: disable=invalid-overridden-method
+        self,
+    ) -> "PutObjectResult":
+        """resumable upload file to oss storage
+
+        Returns:
+            _type_: _description_
+        """
+        await self._load_record()
+
+        parts_to_upload: Collection[
+            "_PartToProcess"
+        ] = self.__get_parts_to_upload(self.__finished_parts)
+        parts_to_upload = sorted(parts_to_upload, key=lambda p: p.part_number)
+        logger.debug("Parts need to upload: %s", parts_to_upload)
+
+        sem = asyncio.Semaphore(self.__num_threads)
+        tasks = [
+            asyncio.ensure_future(self._upload_task(sem, part_to_upload))
+            for part_to_upload in parts_to_upload
+        ]
+        await asyncio.gather(*tasks)
+
+        self._report_progress(self.size)
+
+        headers = _populate_valid_headers(
+            self.__headers, [OSS_REQUEST_PAYER, OSS_OBJECT_ACL]
+        )
+        result = await self.bucket.complete_multipart_upload(
+            self.key, self.__upload_id, self.__finished_parts, headers=headers
+        )
+        self._del_record()
+
+        return result
+
+    async def _upload_task(
+        self, sem: "asyncio.Semaphore", part_to_upload: _PartToProcess
+    ):
+        async with sem:
+            return await self._upload_part(part_to_upload)
+
+    async def _upload_part(self, part: _PartToProcess):
+        with open(to_unicode(self.filename), "rb") as f_r:
+            self._report_progress(self.__finished_size)
+
+            f_r.seek(part.start, os.SEEK_SET)
+            headers = _populate_valid_headers(
+                self.__headers, [OSS_REQUEST_PAYER, OSS_TRAFFIC_LIMIT]
+            )
+            if self.__encryption:
+                result = await self.bucket.upload_part(
+                    self.key,
+                    self.__upload_id,
+                    part.part_number,
+                    FilelikeObjectAdapter(f_r, size=part.size),
+                    headers=headers,
+                    upload_context=self.__upload_context,
+                )
+            else:
+                result = await self.bucket.upload_part(
+                    self.key,
+                    self.__upload_id,
+                    part.part_number,
+                    FilelikeObjectAdapter(f_r, size=part.size),
+                    headers=headers,
+                )
+
+            logger.debug(
+                "Upload part success, add part info to record, part_number: "
+                "%s, etag: %s, size: %s",
+                part.part_number,
+                result.etag,
+                part.size,
+            )
+            self.__finish_part(
+                PartInfo(
+                    part.part_number,
+                    result.etag,
+                    size=part.size,
+                    part_crc=result.crc,
+                )
+            )
+
+    def _verify_record(self, record: Optional[Dict]):
+        if record and not self.__is_record_sane(record):
+            logger.warning(
+                "The content of record is invalid, delete the record"
+            )
+            self._del_record()
+            return None
+
+        if record and self.__file_changed(record):
+            logger.warning(
+                "File: %s has been changed, delete the record", self.filename
+            )
+            self._del_record()
+            return None
+
+        if record and not self.__upload_exists(record["upload_id"]):
+            logger.warning(
+                "Multipart upload: %s does not exist, delete the record",
+                record["upload_id"],
+            )
+            self._del_record()
+            return None
+        return record
+
+    async def init_record(self) -> Dict:
+        """Initialization record for the file to upload."""
+        params = _populate_valid_params(self.__params, [Bucket.SEQUENTIAL])
+        part_size = determine_part_size(self.size, self.__part_size)
+        logger.debug(
+            "Upload File size: %d, User-specify part_size: %d, "
+            "Calculated part_size: %d",
+            self.size,
+            self.__part_size,
+            part_size,
+        )
+        if self.__encryption:
+            upload_context = MultipartUploadCryptoContext(self.size, part_size)
+            init_result = await self.bucket.init_multipart_upload(
+                self.key, self.__headers, params, upload_context
+            )
+            upload_id = init_result.upload_id
+            if self.__record_upload_context:
+                material = upload_context.content_crypto_material
+                material_record = {
+                    "wrap_alg": material.wrap_alg,
+                    "cek_alg": material.cek_alg,
+                    "encrypted_key": b64encode_as_string(
+                        material.encrypted_key
+                    ),
+                    "encrypted_iv": b64encode_as_string(material.encrypted_iv),
+                    "mat_desc": material.mat_desc,
+                }
+        else:
+            init_result = await self.bucket.init_multipart_upload(
+                self.key, self.__headers, params
+            )
+            upload_id = init_result.upload_id
+
+        record = {
+            "op_type": self.__op,
+            "upload_id": upload_id,
+            "file_path": self._abspath,
+            "size": self.size,
+            "mtime": self.__mtime,
+            "bucket": self.bucket.bucket_name,
+            "key": self.key,
+            "part_size": part_size,
+        }
+
+        if self.__record_upload_context:
+            record["content_crypto_material"] = material_record
+
+        logger.debug(
+            "Add new record, bucket: %s, key: %s, upload_id: %s, "
+            "part_size: %d",
+            self.bucket.bucket_name,
+            self.key,
+            upload_id,
+            part_size,
+        )
+
+        self._put_record(record)
+        return record
+
+    async def _get_finished_parts(self):
+        parts = []
+
+        valid_headers = _filter_invalid_headers(
+            self.__headers,
+            [OSS_SERVER_SIDE_ENCRYPTION, OSS_SERVER_SIDE_DATA_ENCRYPTION],
+        )
+
+        async for part in AioPartIterator(
+            self.bucket, self.key, self.__upload_id, headers=valid_headers
+        ):
+            parts.append(part)
+
+        return parts
+
+    async def _load_record(self):
+        record: Optional[Dict] = self._get_record()
+        logger.debug("Load record return %s", record)
+
+        record: Optional[Dict] = self._verify_record(record)
+
+        record: Dict = record or await self.init_record()
+
+        self.__record: Dict = record
+        self.__part_size: int = self.__record["part_size"]
+        self.__upload_id = self.__record["upload_id"]
+        if self.__record_upload_context:
+            if "content_crypto_material" in self.__record:
+                material_record = self.__record["content_crypto_material"]
+                wrap_alg = material_record["wrap_alg"]
+                cek_alg = material_record["cek_alg"]
+                if (
+                    cek_alg != self.bucket.crypto_provider.cipher.alg
+                    or wrap_alg != self.bucket.crypto_provider.wrap_alg
+                ):
+                    err_msg = (
+                        "Envelope or data encryption/decryption "
+                        "algorithm is inconsistent"
+                    )
+                    raise InconsistentError(err_msg, self)
+                content_crypto_material = ContentCryptoMaterial(
+                    self.bucket.crypto_provider.cipher,
+                    material_record["wrap_alg"],
+                    b64decode_from_string(material_record["encrypted_key"]),
+                    b64decode_from_string(material_record["encrypted_iv"]),
+                    material_record["mat_desc"],
+                )
+                self.__upload_context = MultipartUploadCryptoContext(
+                    self.size, self.__part_size, content_crypto_material
+                )
+
+            else:
+                err_msg = (
+                    "If record_upload_context flag is true, "
+                    "content_crypto_material must in the the record"
+                )
+                raise InconsistentError(err_msg, self)
+
+        else:
+            if "content_crypto_material" in self.__record:
+                err_msg = (
+                    "content_crypto_material must in the the record, "
+                    "but record_upload_context flat is false"
+                )
+                raise InvalidEncryptionRequest(err_msg, self)
+
+        self.__finished_parts = await self._get_finished_parts()
+        self.__finished_size = sum(p.size for p in self.__finished_parts)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def bucket_name():
 @pytest.fixture(scope="session")
 def test_directory():
     test_id = uuid.uuid4()
-    return f"ossfs_test/{test_id}"
+    return f"aiooss2_test/{test_id}"
 
 
 @pytest.fixture(scope="session")

--- a/tests/func/test_bucket.py
+++ b/tests/func/test_bucket.py
@@ -1,5 +1,5 @@
 """
-Basic tests for aiooss2
+Basic tests for bucket operations.
 """
 # pylint: disable=missing-function-docstring
 import asyncio

--- a/tests/func/test_object.py
+++ b/tests/func/test_object.py
@@ -1,5 +1,5 @@
 """
-Basic tests for aiooss2
+Functional tests for object operations.
 """
 # pylint: disable=missing-function-docstring
 import asyncio
@@ -40,7 +40,6 @@ def test_put_object(
 
     bucket.enable_crc = enable_crc
     result = asyncio.run(put(object_name, data))
-    bucket.enable_crc = not enable_crc
     assert result.resp.status == 200
     assert oss2_bucket.get_object(object_name).read() == data
 
@@ -55,7 +54,6 @@ def test_get_object(bucket: "AioBucket", number_file, enable_crc: bool):
 
     bucket.enable_crc = enable_crc
     result = asyncio.run(get(number_file))
-    bucket.enable_crc = not enable_crc
     assert result == NUMBERS
 
 
@@ -181,7 +179,6 @@ def test_put_object_from_file(
 
     bucket.enable_crc = enable_crc
     result = asyncio.run(put_object_from_file(object_name, str(file)))
-    bucket.enable_crc = not enable_crc
     assert result.resp.status == 200
     assert oss2_bucket.get_object(object_name).read() == data
 
@@ -200,7 +197,6 @@ def test_get_object_to_file(
 
     bucket.enable_crc = enable_crc
     asyncio.run(get_object_to_file(number_file, str(file)))
-    bucket.enable_crc = not enable_crc
     assert file.read_binary() == NUMBERS
 
 

--- a/tests/func/test_resumable.py
+++ b/tests/func/test_resumable.py
@@ -1,0 +1,59 @@
+"""
+Functional tests for resumable operations.
+"""
+# pylint: disable=missing-function-docstring
+# pylint: disable=too-many-arguments
+import asyncio
+import inspect
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from aiooss2.resumable import resumable_upload
+
+if TYPE_CHECKING:
+    from oss2 import Bucket
+    from py.path import local
+
+    from aiooss2 import AioBucket
+
+
+@pytest.fixture(scope="module", name="test_path")
+def file_path(test_directory):
+    test_file_name = __file__.rsplit(os.sep, maxsplit=1)[-1]
+    return f"{test_directory}/{test_file_name}"
+
+
+@pytest.mark.parametrize("enable_crc", [True, False])
+@pytest.mark.parametrize("size", [100, 2**20])
+def test_resumable_upload_file(
+    tmpdir: "local",
+    bucket: "AioBucket",
+    oss2_bucket: "Bucket",
+    test_path,
+    enable_crc: bool,
+    size: int,
+):
+    data = os.urandom(size)
+    file = tmpdir / "file"
+    file_w = tmpdir / "file_result"
+    function_name = inspect.stack()[0][0].f_code.co_name
+    object_name = f"{test_path}/{function_name}"
+    file.write(data, mode="wb")
+
+    async def resumalbe_upload_coroutine(object_name, file):
+        async with bucket as aiobucket:
+            return await resumable_upload(
+                aiobucket,
+                object_name,
+                file,
+                multipart_threshold=10,
+                part_size=100 * 2**10,
+            )
+
+    bucket.enable_crc = enable_crc
+    result = asyncio.run(resumalbe_upload_coroutine(object_name, str(file)))
+    assert result.resp.status == 200
+    oss2_bucket.get_object_to_file(object_name, file_w)
+    assert oss2_bucket.get_object(object_name).read() == data


### PR DESCRIPTION
fix: #58

Required by large file upload, can continue on previous stop point.

1. Add new iterator multipart iterator.
2. Add a new resumable_upload function.
3. Add a new tests for resumable upload.
4. Add multipart operations to Bucket api
5. Modify tests base name.